### PR TITLE
fix null senderhostname issue, causing zabbix sender failure

### DIFF
--- a/scripts/rabbitmq/api.py
+++ b/scripts/rabbitmq/api.py
@@ -24,7 +24,7 @@ class RabbitMQAPI(object):
         self.host_name = host_name or socket.gethostname()
         self.port = port
         self.conf = conf or '/etc/zabbix/zabbix_agentd.conf'
-        self.senderhostname = senderhostname
+        self.senderhostname = senderhostname if senderhostname else host_name
 
     def call_api(self, path):
         '''Call the REST API and convert the results into JSON.'''


### PR DESCRIPTION
Hi,

Just setup zabbix rabbitmq monitor, with zabbix 2.4 server.

However the item prototype(trapper) of discovery rules "rabbitmq queues"  can't get data.

On the client side, open debug log and get this error:

```
2015-11-26 15:48:58,203 WARNING: zabbix_sender [27201]: Warning: [line 1] '-' encountered as 'Hostname', but no default hostname was specified
2015-11-26 15:50:53,168 WARNING: Sending failed.
```

In the `rabbitmq-status.sh` file, I can't find a `senderhostname` be passwd to `api.py`, so set default `senderhostname` the same to the `host_name`