### PR TITLE
Add option for switching between http and https

### DIFF
--- a/scripts/rabbitmq/api.py
+++ b/scripts/rabbitmq/api.py
@@ -18,17 +18,18 @@ class RabbitMQAPI(object):
     '''Class for RabbitMQ Management API'''
 
     def __init__(self, user_name='guest', password='guest', host_name='',
-                 port=15672, conf='/etc/zabbix/zabbix_agentd.conf', senderhostname=None):
+                 protocol='http', port=15672, conf='/etc/zabbix/zabbix_agentd.conf', senderhostname=None):
         self.user_name = user_name
         self.password = password
         self.host_name = host_name or socket.gethostname()
+        self.protocol = protocol
         self.port = port
         self.conf = conf or '/etc/zabbix/zabbix_agentd.conf'
         self.senderhostname = senderhostname if senderhostname else host_name
 
     def call_api(self, path):
         '''Call the REST API and convert the results into JSON.'''
-        url = 'http://{0}:{1}/api/{2}'.format(self.host_name, self.port, path)
+        url = '{0}://{1}:{2}/api/{3}'.format(self.protocol, self.host_name, self.port, path)
         password_mgr = urllib2.HTTPPasswordMgrWithDefaultRealm()
         password_mgr.add_password(None, url, self.user_name, self.password)
         handler = urllib2.HTTPBasicAuthHandler(password_mgr)
@@ -163,6 +164,8 @@ def main():
                       default='guest')
     parser.add_option('--hostname', help='RabbitMQ API host',
                       default=socket.gethostname())
+    parser.add_option('--protocol', help='RabbitMQ API protocol (http or https)',
+                      default='http')
     parser.add_option('--port', help='RabbitMQ API port', type='int',
                       default=15672)
     parser.add_option('--check', type='choice', choices=choices,
@@ -177,7 +180,7 @@ def main():
         parser.error('At least one check should be specified')
     logging.debug("Started trying to process data")
     api = RabbitMQAPI(user_name=options.username, password=options.password,
-                      host_name=options.hostname, port=options.port,
+                      host_name=options.hostname, protocol=options.protocol, port=options.port,
                       conf=options.conf, senderhostname=options.senderhostname)
     if options.filters:
         try:


### PR DESCRIPTION
RabbitMQ supports API calls via https (when encryption is enabled and certificates provided). This patch enables `api.py` to query https enabled RabbitMQ APIs. Default is `http`.