### PR TITLE
Fixed a typo that leads to error on zabbix agent

### DIFF
--- a/rabbitmq.template.xml
+++ b/rabbitmq.template.xml
@@ -770,7 +770,7 @@
                     <type>7</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>rabbitmq.discovery_queue</key>
+                    <key>rabbitmq.discovery_queues</key>
                     <delay>360</delay>
                     <status>0</status>
                     <allowed_hosts/>

--- a/zabbix_agentd.d/zabbix-rabbitmq.conf
+++ b/zabbix_agentd.d/zabbix-rabbitmq.conf
@@ -1,4 +1,4 @@
 UserParameter=rabbitmq.discovery_queue,/etc/zabbix/scripts/rabbitmq/list_rabbit_queues.sh
-UserParameter=rabbitmq.discovery_shovel,/etc/zabbix/scripts/rabbitmq/list_rabbit_shovels.sh
+UserParameter=rabbitmq.discovery_shovels,/etc/zabbix/scripts/rabbitmq/list_rabbit_shovels.sh
 UserParameter=rabbitmq.discovery_nodes,/etc/zabbix/scripts/rabbitmq/list_rabbit_nodes.sh
 UserParameter=rabbitmq[*],/etc/zabbix/scripts/rabbitmq/rabbitmq-status.sh $1 $2 $3

--- a/zabbix_agentd.d/zabbix-rabbitmq.conf
+++ b/zabbix_agentd.d/zabbix-rabbitmq.conf
@@ -1,4 +1,4 @@
-UserParameter=rabbitmq.discovery_queue,/etc/zabbix/scripts/rabbitmq/list_rabbit_queues.sh
+UserParameter=rabbitmq.discovery_queues,/etc/zabbix/scripts/rabbitmq/list_rabbit_queues.sh
 UserParameter=rabbitmq.discovery_shovels,/etc/zabbix/scripts/rabbitmq/list_rabbit_shovels.sh
 UserParameter=rabbitmq.discovery_nodes,/etc/zabbix/scripts/rabbitmq/list_rabbit_nodes.sh
 UserParameter=rabbitmq[*],/etc/zabbix/scripts/rabbitmq/rabbitmq-status.sh $1 $2 $3


### PR DESCRIPTION
active check "rabbitmq.discovery_shovels" is not supported: Unsupported item key.