### PR TITLE
Add tracking of the acknowledgements on a queue

### DIFF
--- a/rabbitmq.template.xml
+++ b/rabbitmq.template.xml
@@ -1112,6 +1112,49 @@
                             <snmp_community/>
                             <multiplier>0</multiplier>
                             <snmp_oid/>
+                            <key>rabbitmq.queues[{#VHOSTNAME},queue_message_stats_ack,{#QUEUENAME}]</key>
+                            <delay>0</delay>
+                            <history>7</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>msgs/s</units>
+                            <delta>1</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Rate of message acknowledgement per queue</description>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>rabbitmq data</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>RabbitMQ $2 on vhost $1, queue $3</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
                             <key>rabbitmq.queues[{#VHOSTNAME},queue_message_stats_publish,{#QUEUENAME}]</key>
                             <delay>0</delay>
                             <history>7</history>
@@ -1316,6 +1359,18 @@
                                     <item>
                                         <host>Template App RabbitMQ v3</host>
                                         <key>rabbitmq.queues[{#VHOSTNAME},queue_message_stats_publish,{#QUEUENAME}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>3</sortorder>
+                                    <drawtype>0</drawtype>
+                                    <color>0000C8</color>
+                                    <yaxisside>0</yaxisside>
+                                    <calc_fnc>2</calc_fnc>
+                                    <type>0</type>
+                                    <item>
+                                        <host>Template App RabbitMQ v3</host>
+                                        <key>rabbitmq.queues[{#VHOSTNAME},queue_message_stats_ack,{#QUEUENAME}]</key>
                                     </item>
                                 </graph_item>
                             </graph_items>

--- a/scripts/rabbitmq/api.py
+++ b/scripts/rabbitmq/api.py
@@ -163,7 +163,7 @@ class RabbitMQAPI(object):
             logging.debug("SENDER_DATA: - %s %s" % (key,value))
             tmpfile.write("- %s %s\n" % (key, value))
         ##  This is a non standard bit of information added after the standard items
-        for item in ['deliver_get', 'publish']:
+        for item in ['deliver_get', 'publish', 'ack']:
             key = '"rabbitmq.queues[{0},queue_message_stats_{1},{2}]"'
             key = key.format(queue['vhost'], item, queue['name'])
             value = queue.get('message_stats', {}).get(item, 0)
@@ -202,6 +202,8 @@ class RabbitMQAPI(object):
           return self.call_api('overview').get('message_stats', {}).get('deliver_get_details', {}).get('rate',0)
         elif item == 'message_stats_publish':
           return self.call_api('overview').get('message_stats', {}).get('publish_details', {}).get('rate',0)
+        elif item == 'message_stats_ack':
+          return self.call_api('overview').get('message_stats', {}).get('ack_details', {}).get('rate',0)
         elif item == 'message_count_total':
           return self.call_api('overview').get('queue_totals', {}).get('messages',0)
         elif item == 'message_count_ready':


### PR DESCRIPTION
Actual acknowledgement speed on the queue was more important for us to track than deliveries, as there may be messages redelivered, a Poison Message issue may arise, etc. However, this is only of use when messages are actually acknowledged, so I left it out of the default triggers.