### PR TITLE
Fix problem with missing Hostname in zabbix config

### DIFF
--- a/scripts/rabbitmq/api.py
+++ b/scripts/rabbitmq/api.py
@@ -23,7 +23,7 @@ class RabbitMQAPI(object):
         self.host_name = host_name or socket.gethostname()
         self.port = port
         self.conf = conf or '/etc/zabbix/zabbix_agentd.conf'
-        self.senderhostname = senderhostname
+        self.senderhostname = senderhostname or socket.gethostname()
         self.protocol = protocol or 'http'
 
     def call_api(self, path):


### PR DESCRIPTION
Fixed my problem with missing Hostname in zabbix config.
According to zabbix documentation Hostname is optional.